### PR TITLE
Add artifact logging and visualization tooling

### DIFF
--- a/experiments/run_tinyshakespeare.py
+++ b/experiments/run_tinyshakespeare.py
@@ -1,13 +1,42 @@
 import argparse
+import csv
+import json
 import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--config", type=str, default="experiments/tinyshakespeare.yaml")
 parser.add_argument("--size", type=str, default=None, help="override model size preset")
-parser.add_argument("--device", type=str, default="cpu", choices=["cpu", "cuda"], help="cpu or cuda (requires CuPy & NVIDIA CUDA)")
+parser.add_argument(
+    "--device",
+    type=str,
+    default="cpu",
+    choices=["cpu", "cuda"],
+    help="cpu or cuda (requires CuPy & NVIDIA CUDA)",
+)
 parser.add_argument("--save_every", type=int, default=0, help="save checkpoint every N steps (0 = only at end)")
 parser.add_argument("--out", type=str, default="checkpoints/last.pkl")
+parser.add_argument("--metrics_every", type=int, default=1, help="record metrics every N steps")
+parser.add_argument("--metrics_csv", type=str, default=None, help="CSV file to write per-step metrics")
+parser.add_argument("--metrics_json", type=str, default=None, help="JSON file to write per-step metrics")
+parser.add_argument("--loss_plot", type=str, default=None, help="PNG file for the loss curve plot")
 args, _ = parser.parse_known_args()
+
+if args.metrics_every < 1:
+    raise ValueError("--metrics_every must be >= 1")
+
+plt = None
+_matplotlib_error: Exception | None = None
+if args.loss_plot:
+    try:
+        import matplotlib  # type: ignore
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt  # type: ignore
+    except Exception as exc:  # pragma: no cover - import failure
+        _matplotlib_error = exc
 
 os.environ["SCRATCH_DEVICE"] = args.device
 
@@ -19,8 +48,60 @@ from scratch_transformer.optim import AdamW  # noqa: E402
 from scratch_transformer.trainer import Trainer  # noqa: E402
 from scratch_transformer.utils import Timer, count_params  # noqa: E402
 
-cfg_txt = open(args.config).read().strip().splitlines()
-raw = {}
+
+def _ensure_parent(path_str: str | None) -> Path | None:
+    if path_str is None:
+        return None
+    path = Path(path_str)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _dump_metrics_csv(path: Path, history: List[Dict[str, Any]]) -> None:
+    if not history:
+        return
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["step", "loss", "elapsed_sec"])
+        writer.writeheader()
+        for row in history:
+            writer.writerow(row)
+
+
+def _dump_metrics_json(path: Path, history: List[Dict[str, Any]], metadata: Dict[str, Any]) -> None:
+    if not history and not metadata:
+        return
+    payload = {
+        "created_at": datetime.utcnow().isoformat() + "Z",
+        "history": history,
+        "metadata": metadata,
+    }
+    with path.open("w") as handle:
+        json.dump(payload, handle, indent=2)
+
+
+def _save_loss_plot(path: Path, history: List[Dict[str, Any]]) -> None:
+    if plt is None:
+        if _matplotlib_error is not None:
+            print(f"[warn] Matplotlib unavailable ({_matplotlib_error}). Skipping plot: {path}")
+        return
+    if not history:
+        print(f"[plot] No history captured; skipping plot {path}")
+        return
+    steps = [row["step"] for row in history]
+    losses = [row["loss"] for row in history]
+    plt.figure(figsize=(8, 4.5))
+    plt.plot(steps, losses, marker="o", linewidth=1.5, markersize=2)
+    plt.title("Training loss")
+    plt.xlabel("Step")
+    plt.ylabel("Loss")
+    plt.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(path, dpi=160)
+    plt.close()
+
+
+cfg_txt = Path(args.config).read_text().strip().splitlines()
+raw: Dict[str, str] = {}
 for line in cfg_txt:
     line = line.strip()
     if not line or line.startswith("#"):
@@ -57,16 +138,28 @@ model = Transformer(
     max_seq_len=cfg.max_seq_len,
 )
 
+param_count = count_params(model.parameters())
 opt = AdamW(model.parameters(), lr=lr, weight_decay=wd)
 trainer = Trainer(model, opt, cfg.vocab_size, grad_clip=clip)
 
-print(f"Model params: {count_params(model.parameters()):,}")
+print(f"Model params: {param_count:,}")
 
 os.makedirs("checkpoints", exist_ok=True)
+metrics_history: List[Dict[str, Any]] = []
 timer = Timer()
+last_loss = float("nan")
 for step in range(1, steps + 1):
     x, y = D.get_batch("train", batch_size=bs)
     loss = trainer.step(x, y)
+    last_loss = float(loss)
+    if step % args.metrics_every == 0:
+        metrics_history.append(
+            {
+                "step": step,
+                "loss": last_loss,
+                "elapsed_sec": timer.elapsed(),
+            }
+        )
     if step % print_every == 0:
         print(f"step {step:6d} | loss {loss:.4f}")
     if args.save_every and step % args.save_every == 0:
@@ -76,3 +169,59 @@ for step in range(1, steps + 1):
 save_params(model.parameters(), args.out)
 print("Done. Saved:", args.out)
 
+if steps > 0:
+    final_elapsed = timer.elapsed()
+    if not metrics_history or metrics_history[-1]["step"] != steps:
+        metrics_history.append(
+            {
+                "step": steps,
+                "loss": last_loss,
+                "elapsed_sec": final_elapsed,
+            }
+        )
+else:
+    final_elapsed = timer.elapsed()
+
+metrics_csv_path = _ensure_parent(args.metrics_csv)
+if metrics_csv_path is not None:
+    _dump_metrics_csv(metrics_csv_path, metrics_history)
+    if metrics_csv_path.exists():
+        print(f"[metrics] wrote CSV -> {metrics_csv_path}")
+
+metrics_json_path = _ensure_parent(args.metrics_json)
+metadata: Dict[str, Any] = {
+    "config_file": os.path.abspath(args.config),
+    "preset": preset_name,
+    "steps": steps,
+    "batch_size": bs,
+    "seq_len": seq,
+    "lr": lr,
+    "weight_decay": wd,
+    "grad_clip": clip,
+    "print_every": print_every,
+    "metrics_every": args.metrics_every,
+    "device": args.device,
+    "save_every": args.save_every,
+    "checkpoint": os.path.abspath(args.out),
+    "param_count": param_count,
+    "dataset": os.path.abspath(train_path),
+    "total_train_time_sec": final_elapsed,
+}
+if metrics_history:
+    metadata["final_step"] = metrics_history[-1]["step"]
+    metadata["final_loss"] = metrics_history[-1]["loss"]
+else:
+    metadata["final_step"] = steps
+    metadata["final_loss"] = last_loss
+metadata["completed_at"] = datetime.utcnow().isoformat() + "Z"
+
+if metrics_json_path is not None:
+    _dump_metrics_json(metrics_json_path, metrics_history, metadata)
+    if metrics_json_path.exists():
+        print(f"[metrics] wrote JSON -> {metrics_json_path}")
+
+loss_plot_path = _ensure_parent(args.loss_plot)
+if loss_plot_path is not None:
+    _save_loss_plot(loss_plot_path, metrics_history)
+    if loss_plot_path.exists():
+        print(f"[plot] wrote loss curve -> {loss_plot_path}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.24
 cupy-cuda12x>=12.0; platform_system != "Windows"
+matplotlib>=3.7

--- a/scratch_transformer/utils.py
+++ b/scratch_transformer/utils.py
@@ -9,6 +9,7 @@ np.set_printoptions(precision=4, suppress=True)
 class Timer:
     def __init__(self) -> None:
         self.t0 = time.time()
+        self._start = self.t0
 
     def lap(self, msg: str = "") -> float:
         t = time.time() - self.t0
@@ -16,6 +17,10 @@ class Timer:
         if msg:
             print(f"[timer] {msg}: {t:.3f}s")
         return t
+
+    def elapsed(self) -> float:
+        """Return the total number of seconds since the timer started."""
+        return time.time() - self._start
 
 
 def count_params(param_dict: Dict[str, np.ndarray]) -> int:

--- a/scripts/package_artifacts.py
+++ b/scripts/package_artifacts.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+"""Collect training artifacts, build a manifest, and optionally sync to local storage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import tarfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", required=True, help="Directory to collect artifacts into")
+    parser.add_argument("--checkpoint", action="append", default=[], help="Checkpoint file(s) to include")
+    parser.add_argument("--include", action="append", default=[], help="Additional files to include")
+    parser.add_argument("--archive", type=str, default=None, help="Path of the .tar.gz archive to create")
+    parser.add_argument(
+        "--download",
+        type=str,
+        default=None,
+        help="Optional rsync/scp destination (for example user@host:/path)",
+    )
+    parser.add_argument(
+        "--download-method",
+        type=str,
+        default="rsync",
+        choices=["rsync", "scp"],
+        help="Command used to push the archive to --download",
+    )
+    parser.add_argument(
+        "--manifest-name",
+        type=str,
+        default="manifest.json",
+        help="Name of the manifest file written inside the artifact directory",
+    )
+    return parser.parse_args()
+
+
+def _iter_paths(values: Iterable[str]) -> List[Path]:
+    paths: List[Path] = []
+    for value in values:
+        if not value:
+            continue
+        paths.append(Path(value).expanduser())
+    return paths
+
+
+def _stage_path(src: Path, dest_dir: Path) -> Tuple[Path, Path] | None:
+    if not src.exists():
+        print(f"[warn] skipping missing artifact: {src}")
+        return None
+    src = src.resolve()
+    dest_dir = dest_dir.resolve()
+    if dest_dir == src or dest_dir in src.parents:
+        return src, src
+    dest = dest_dir / src.name
+    if src.is_dir():
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(src, dest)
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+    return dest, src
+
+
+def _walk_size(path: Path) -> int:
+    if path.is_file():
+        return path.stat().st_size
+    total = 0
+    for item in path.rglob("*"):
+        if item.is_file():
+            total += item.stat().st_size
+    return total
+
+
+def _human_bytes(num: int) -> str:
+    step = 1024.0
+    size = float(num)
+    units = ["B", "KB", "MB", "GB", "TB"]
+    for unit in units:
+        if size < step or unit == units[-1]:
+            return f"{size:.2f} {unit}"
+        size /= step
+    return f"{size:.2f} PB"
+
+
+def main() -> None:
+    args = _parse_args()
+    artifact_dir = Path(args.artifact_dir).expanduser().resolve()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    staged: Dict[Path, Dict[str, Path]] = {}
+    for candidate in _iter_paths(args.checkpoint) + _iter_paths(args.include):
+        result = _stage_path(candidate, artifact_dir)
+        if result is None:
+            continue
+        staged_path, original_path = result
+        key = staged_path.resolve()
+        if key in staged:
+            continue
+        staged[key] = {"dest": staged_path, "source": original_path}
+
+    manifest_entries = []
+    for entry in staged.values():
+        dest = entry["dest"].resolve()
+        source = entry["source"].resolve()
+        try:
+            relative = dest.relative_to(artifact_dir)
+        except ValueError:
+            relative = dest.name
+        size_bytes = _walk_size(dest)
+        manifest_entries.append(
+            {
+                "name": dest.name,
+                "relative_path": str(relative),
+                "size_bytes": size_bytes,
+                "size_human": _human_bytes(size_bytes),
+                "source": str(source),
+            }
+        )
+
+    manifest = {
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "artifact_dir": str(artifact_dir),
+        "entries": manifest_entries,
+    }
+
+    manifest_path = artifact_dir / args.manifest_name
+    with manifest_path.open("w") as handle:
+        json.dump(manifest, handle, indent=2)
+    print(f"[manifest] wrote {manifest_path}")
+
+    archive_path = Path(args.archive) if args.archive else artifact_dir.with_suffix(".tar.gz")
+    archive_path = archive_path.expanduser().resolve()
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(artifact_dir, arcname=artifact_dir.name)
+    print(f"[archive] created {archive_path}")
+
+    manifest["archive"] = str(archive_path)
+    with manifest_path.open("w") as handle:
+        json.dump(manifest, handle, indent=2)
+
+    if args.download:
+        cmd = (
+            ["rsync", "-av", str(archive_path), args.download]
+            if args.download_method == "rsync"
+            else ["scp", str(archive_path), args.download]
+        )
+        print(f"[download] running: {' '.join(cmd)}")
+        result = subprocess.run(cmd, check=False)
+        if result.returncode != 0:
+            print(
+                "[download] WARNING: copy failed with exit code"
+                f" {result.returncode}. Transfer the archive manually."
+            )
+        else:
+            print(f"[download] archive copied to {args.download}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prime_single_train.sh
+++ b/scripts/prime_single_train.sh
@@ -8,13 +8,45 @@ conda activate ${SCRATCH_ENV_NAME:-scratch-transformer}
 
 export SCRATCH_DEVICE=cuda
 
-mkdir -p checkpoints
+mkdir -p checkpoints artifacts
+
+timestamp=$(date +%Y%m%d-%H%M%S)
+run_name="tinyshakespeare-${timestamp}"
+checkpoint_path="checkpoints/${run_name}.pkl"
+artifact_dir="artifacts/${run_name}"
+metrics_csv="${artifact_dir}/training_metrics.csv"
+metrics_json="${artifact_dir}/training_metrics.json"
+loss_plot="${artifact_dir}/training_loss.png"
+log_file="${artifact_dir}/train.log"
+
+mkdir -p "${artifact_dir}"
 
 python experiments/run_tinyshakespeare.py \
   --config experiments/tinyshakespeare.yaml \
   --device cuda \
-  --out checkpoints/tinyshakespeare-$(date +%Y%m%d-%H%M%S).pkl \
-  --save_every 1000
+  --out "${checkpoint_path}" \
+  --save_every 1000 \
+  --metrics_csv "${metrics_csv}" \
+  --metrics_json "${metrics_json}" \
+  --loss_plot "${loss_plot}" \
+  2>&1 | tee "${log_file}"
+
+archive_path="${artifact_dir}.tar.gz"
+
+python scripts/package_artifacts.py \
+  --artifact-dir "${artifact_dir}" \
+  --checkpoint "${checkpoint_path}" \
+  --include "${metrics_csv}" \
+  --include "${metrics_json}" \
+  --include "${loss_plot}" \
+  --include "${log_file}" \
+  --archive "${archive_path}" \
+  ${SCRATCH_AUTO_DOWNLOAD_TARGET:+--download "${SCRATCH_AUTO_DOWNLOAD_TARGET}"} \
+  ${SCRATCH_AUTO_DOWNLOAD_METHOD:+--download-method "${SCRATCH_AUTO_DOWNLOAD_METHOD}"}
 
 echo "[train] Done. Checkpoints are in ./checkpoints"
+echo "[artifacts] Run outputs stored in ${artifact_dir}"
+if [[ -n "${SCRATCH_AUTO_DOWNLOAD_TARGET:-}" ]]; then
+  echo "[artifacts] Archive sync attempted to ${SCRATCH_AUTO_DOWNLOAD_TARGET} using ${SCRATCH_AUTO_DOWNLOAD_METHOD:-rsync}"
+fi
 


### PR DESCRIPTION
## Summary
- record per-step metrics, persist them to CSV/JSON, and render a loss plot in `experiments/run_tinyshakespeare.py`
- expose an `elapsed()` helper on the training timer to drive artifact metadata
- add an artifact packaging utility and update the Prime Intellect training script to capture logs, plots, and checkpoints, with optional rsync/scp syncing
- include matplotlib in the dependencies for headless plotting support

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9361765ec8323a4cfc910d321b040