### PR TITLE
Handle inline comments in tinyshakespeare config parser

### DIFF
--- a/experiments/run_tinyshakespeare.py
+++ b/experiments/run_tinyshakespeare.py
@@ -104,7 +104,8 @@ cfg_txt = Path(args.config).read_text().strip().splitlines()
 raw: Dict[str, str] = {}
 for line in cfg_txt:
     line = line.strip()
-    if not line or line.startswith("#"):
+    line = line.split("#", 1)[0].strip()
+    if not line:
         continue
     k, v = [x.strip() for x in line.split(":", 1)]
     raw[k] = v


### PR DESCRIPTION
## Summary
- strip inline comments when reading the tinyshakespeare experiment config
- skip empty lines after comment removal to avoid parsing invalid entries

## Testing
- python - <<'PY'
from pathlib import Path
from scratch_transformer.config import PRESETS
cfg_txt = Path('experiments/tinyshakespeare.yaml').read_text().strip().splitlines()
raw = {}
for line in cfg_txt:
    line = line.strip()
    line = line.split('#', 1)[0].strip()
    if not line:
        continue
    k, v = [x.strip() for x in line.split(':', 1)]
    raw[k] = v
preset_name = raw.get('size', 'mini2p5m')
print('preset_name:', preset_name)
print('preset_exists:', preset_name in PRESETS)
PY

------
https://chatgpt.com/codex/tasks/task_e_68c950da6f008323b1d46a526055d056